### PR TITLE
Allow specifying subperiod for aggregate functions

### DIFF
--- a/src/parser/ast.rs
+++ b/src/parser/ast.rs
@@ -500,7 +500,7 @@ pub struct AggregateExpr {
     #[cfg_attr(feature = "ser", serde(flatten))]
     #[cfg_attr(feature = "ser", serde(serialize_with = "serialize_grouping"))]
     pub modifier: Option<LabelModifier>,
-    // The subperiod to aggregate over. Aggregates over the entire period if not specified.
+    /// The subperiod to aggregate over. Aggregates over the entire period if not specified.
     pub subperiod: Option<Duration>,
 }
 

--- a/src/parser/ast.rs
+++ b/src/parser/ast.rs
@@ -500,7 +500,7 @@ pub struct AggregateExpr {
     #[cfg_attr(feature = "ser", serde(flatten))]
     #[cfg_attr(feature = "ser", serde(serialize_with = "serialize_grouping"))]
     pub modifier: Option<LabelModifier>,
-    // The subperiod to aggregate over. If not specified, aggregates over the entire period.
+    // The subperiod to aggregate over. Aggregates over the entire period if not specified.
     pub subperiod: Option<Duration>,
 }
 

--- a/src/parser/ast.rs
+++ b/src/parser/ast.rs
@@ -500,6 +500,8 @@ pub struct AggregateExpr {
     #[cfg_attr(feature = "ser", serde(flatten))]
     #[cfg_attr(feature = "ser", serde(serialize_with = "serialize_grouping"))]
     pub modifier: Option<LabelModifier>,
+    // The subperiod to aggregate over. If not specified, aggregates over the entire period.
+    pub subperiod: Option<Duration>,
 }
 
 impl AggregateExpr {
@@ -1159,6 +1161,10 @@ impl Expr {
                 let ms = Expr::MatrixSelector(MatrixSelector { vs, range });
                 Ok(ms)
             }
+            Expr::Aggregate(mut ae) => {
+                ae.subperiod = Some(range);
+                Ok(Expr::Aggregate(ae))
+            }
             _ => Err("ranges only allowed for vector selectors".into()),
         }
     }
@@ -1274,6 +1280,7 @@ impl Expr {
                 expr,
                 param,
                 modifier,
+                subperiod: None,
             })),
             None => Err(
                 "aggregate operation needs a single instant vector parameter, but found none"

--- a/src/parser/parse.rs
+++ b/src/parser/parse.rs
@@ -1214,6 +1214,15 @@ mod tests {
                 let ex = Expr::from(VectorSelector::from("sum"));
                 Expr::new_aggregate_expr(token::T_SUM, None, FunctionArgs::new_args(ex))
             }),
+            ("sum(test)[5s]", {
+                let ex = Expr::from(VectorSelector::from("test"));
+                let mut ae =
+                    Expr::new_aggregate_expr(token::T_SUM, None, FunctionArgs::new_args(ex));
+                if let Ok(Expr::Aggregate(a)) = &mut ae {
+                    a.subperiod = Some(Duration::from_secs(5));
+                }
+                ae
+            }),
         ];
         assert_cases(Case::new_result_cases(cases));
 
@@ -1250,6 +1259,10 @@ mod tests {
             (
                 "rate(some_metric[5m]) @ 1234",
                 "@ modifier must be preceded by an vector selector or matrix selector or a subquery"
+            ),
+            (
+                "sum(test)[]",
+                "missing unit character in duration"
             ),
         ];
         assert_cases(Case::new_fail_cases(fail_cases));


### PR DESCRIPTION
### Description

- Update grammar to allow specifying subperiod for aggregate functions

- eg. `sum(metric_name)[5m]` will sum over 5 min periods and return a vector rather than a scalar

Related to [TAC-11](https://merms.atlassian.net/browse/TAC-11)